### PR TITLE
Require 'io/console' to use noecho method on $stdin

### DIFF
--- a/lib/bogo-ui/ui.rb
+++ b/lib/bogo-ui/ui.rb
@@ -1,5 +1,6 @@
 require 'bogo-ui'
 require 'paint'
+require 'io/console'
 
 module Bogo
   # CLI UI helper


### PR DESCRIPTION
According to Ruby's stdlib documentation, the 'io/console' module must
be required before using the `noecho` method on an IO object:

<http://ruby-doc.org/stdlib-2.0.0/libdoc/io/console/rdoc/IO.html#method-i-noecho>

Otherwise, the code crashes with:

```
[Sfn]: Chef Validator: ERROR: NoMethodError: undefined method `noecho' for #<IO:<STDIN>>
/var/lib/gems/2.5.0/gems/bogo-ui-0.1.24/lib/bogo-ui/ui.rb:155:in `ask'
/var/lib/gems/2.5.0/gems/sfn-3.0.29f2/lib/sfn/command_module/stack.rb:206:in `set_parameter'
/var/lib/gems/2.5.0/gems/sfn-3.0.29f2/lib/sfn/command_module/stack.rb:278:in `block in populate_parameters!'
/var/lib/gems/2.5.0/gems/sfn-3.0.29f2/lib/sfn/command_module/stack.rb:247:in `each'
/var/lib/gems/2.5.0/gems/sfn-3.0.29f2/lib/sfn/command_module/stack.rb:247:in `populate_parameters!'
/var/lib/gems/2.5.0/gems/sfn-3.0.29f2/lib/sfn/command/update.rb:89:in `execute!'
/var/lib/gems/2.5.0/gems/sfn-3.0.29f2/bin/sfn:52:in `block (4 levels) in <top (required)>'
/var/lib/gems/2.5.0/gems/bogo-cli-0.2.12/lib/bogo-cli/setup.rb:26:in `block in bogo_cli_run'
/var/lib/gems/2.5.0/gems/slop-3.6.0/lib/slop.rb:260:in `parse!'
/var/lib/gems/2.5.0/gems/slop-3.6.0/lib/slop.rb:235:in `parse!'
/var/lib/gems/2.5.0/gems/slop-3.6.0/lib/slop.rb:65:in `parse!'
/var/lib/gems/2.5.0/gems/slop-3.6.0/lib/slop.rb:54:in `parse'
/var/lib/gems/2.5.0/gems/bogo-cli-0.2.12/lib/bogo-cli/setup.rb:48:in `define'
/var/lib/gems/2.5.0/gems/sfn-3.0.29f2/bin/sfn:14:in `<top (required)>'
/usr/local/bin/sfn:23:in `load'
/usr/local/bin/sfn:23:in `<main>'
```